### PR TITLE
Handle Count Prefix in Thumbnail Movements

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The following general key commands are available:
 
 The following additional key commands are available in *thumbnail mode*:
 
-    h,j,k,l      Move selection left/down/up/right
+    h,j,k,l      Move selection left/down/up/right [count] times
     Ctrl-j,k     Scroll thumbnail grid one window height down/up
 
 The following additional key commands are available in *image mode*:

--- a/commands.c
+++ b/commands.c
@@ -209,7 +209,7 @@ bool it_scroll_move(arg_t a) {
 	if (mode == MODE_IMAGE)
 		return img_pan(&img, dir, prefix);
 	else
-		return tns_move_selection(&tns, dir);
+		return tns_move_selection(&tns, dir, prefix);
 }
 
 bool it_scroll_screen(arg_t a) {

--- a/sxiv.1
+++ b/sxiv.1
@@ -126,16 +126,24 @@ Remove current image from file list and go to next image.
 The following keyboard commands are only available in thumbnail mode:
 .TP
 .BR h ", " Left
-Move selection left.
+Move selection left
+.I count
+times.
 .TP
 .BR j ", " Down
-Move selection down.
+Move selection down
+.I count
+times.
 .TP
 .BR k ", " Up
-Move selection up.
+Move selection up
+.I count
+times.
 .TP
 .BR l ", " Right
-Move selection right.
+Move selection right
+.I count
+times.
 .TP
 .BR Ctrl-j ", " Ctrl-Down
 Scroll thumbnail grid one window height down.

--- a/thumbs.c
+++ b/thumbs.c
@@ -390,8 +390,9 @@ void tns_highlight(tns_t *tns, int n, bool hl) {
 	}
 }
 
-bool tns_move_selection(tns_t *tns, direction_t dir) {
+bool tns_move_selection(tns_t *tns, direction_t dir, int count) {
 	int old;
+    int c = (count > 0 ? count : 1);
 
 	if (tns == NULL || tns->thumbs == NULL)
 		return false;
@@ -400,22 +401,16 @@ bool tns_move_selection(tns_t *tns, direction_t dir) {
 
 	switch (dir) {
 		case DIR_UP:
-			if (tns->sel >= tns->cols)
-				tns->sel -= tns->cols;
+            tns->sel = MAX(tns->sel - c * tns->cols, tns->sel % tns->cols);
 			break;
 		case DIR_DOWN:
-			if (tns->sel + tns->cols < tns->cnt)
-				tns->sel += tns->cols;
-			else if (tns->sel < tns->cnt - tns->cnt % tns->cols)
-				tns->sel = tns->cnt - 1;
+            tns->sel = MIN(tns->sel + c * tns->cols, tns->cols * ((tns->cnt - 1) / tns->cols) + MIN((tns->cnt - 1) % tns->cols, tns->sel % tns->cols));
 			break;
 		case DIR_LEFT:
-			if (tns->sel > 0)
-				tns->sel--;
+            tns->sel = MAX(tns->sel - c, 0);
 			break;
 		case DIR_RIGHT:
-			if (tns->sel < tns->cnt - 1)
-				tns->sel++;
+			tns->sel = MIN(tns->sel + c, tns->cnt - 1);
 			break;
 	}
 

--- a/thumbs.h
+++ b/thumbs.h
@@ -61,7 +61,7 @@ bool tns_load(tns_t*, int, const fileinfo_t*, bool, bool);
 void tns_render(tns_t*);
 void tns_highlight(tns_t*, int, bool);
 
-bool tns_move_selection(tns_t*, direction_t);
+bool tns_move_selection(tns_t*, direction_t, int);
 bool tns_scroll(tns_t*, direction_t, bool);
 
 int tns_translate(tns_t*, int, int);


### PR DESCRIPTION
I realized the numeric prefix was not handled in thumbnail movements, so I implemented it.
