### PR TITLE
Added a command line switch for turning on "Show transparency as white" by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ of small previews is displayed, making it easy to choose an image to open.
 
 **Command line options:**
 
+    -A           Show transparency as white by default
     -b           Do not show info bar on bottom of window
     -c           Remove all orphaned cache files from thumbnail cache and exit
     -d           Scale all images to 100%, but fit large images into window

--- a/image.c
+++ b/image.c
@@ -63,7 +63,7 @@ void img_init(img_t *img, win_t *win)
 	img->checkpan = false;
 	img->dirty = false;
 	img->aa = options->aa;
-	img->alpha = true;
+	img->alpha = options->alpha;
 	img->multi.cap = img->multi.cnt = 0;
 	img->multi.animate = false;
 }

--- a/options.c
+++ b/options.c
@@ -33,7 +33,7 @@ const options_t *options = (const options_t*) &_options;
 
 void print_usage(void)
 {
-	printf("usage: sxiv [-bcdFfhiopqrstvZ] [-g GEOMETRY] [-n NUM] "
+	printf("usage: sxiv [-AbcdFfhiopqrstvZ] [-g GEOMETRY] [-n NUM] "
 	       "[-N name] [-z ZOOM] FILES...\n");
 }
 
@@ -54,6 +54,7 @@ void parse_options(int argc, char **argv)
 	_options.scalemode = SCALE_MODE;
 	_options.zoom = 1.0;
 	_options.aa = true;
+  _options.alpha = true;
 
 	_options.fixed_win = false;
 	_options.fullscreen = false;
@@ -65,11 +66,14 @@ void parse_options(int argc, char **argv)
 	_options.thumb_mode = false;
 	_options.clean_cache = false;
 
-	while ((opt = getopt(argc, argv, "bcdFfg:hin:N:opqrstvZz:")) != -1) {
+	while ((opt = getopt(argc, argv, "AbcdFfg:hin:N:opqrstvZz:")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
 				exit(EXIT_FAILURE);
+			case 'A':
+				_options.alpha = false;
+				break;
 			case 'b':
 				_options.hide_bar = true;
 				break;

--- a/options.h
+++ b/options.h
@@ -35,6 +35,7 @@ typedef struct {
 	scalemode_t scalemode;
 	float zoom;
 	bool aa;
+  bool alpha;
 
 	/* window: */
 	bool fixed_win;

--- a/sxiv.1
+++ b/sxiv.1
@@ -26,7 +26,10 @@ for information on how to enable this feature.
 .P
 Please note, that the fullscreen mode requires an EWMH/NetWM compliant window
 manager.
-.SH OPTIONS
+.SH options
+.TP
+.B \-A
+Show transparency as white by default.
 .TP
 .B \-b
 Do not show info bar on bottom of window.


### PR DESCRIPTION
Thanks for your great program! I'm using it on arch linux with awesome wm, and it really is a godsend for tiling WMs.

This patch is useful to me, as I have a ton of pngs with transparency for publication, and manually switching transparency to white after every time opening an image can be a hassle. Now I (or anyone else) can just do alias sxiv="sxiv -A" and be done with it. Shouldn't change the default behaviour of the program. I hope I got all the help and manpage bits correct.

Matthias
