### PR TITLE
moved EXEC_REL_DIR from main.c to config.def.h

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1,3 +1,5 @@
+#define EXEC_REL_DIR ".sxiv/exec"
+
 #ifdef _WINDOW_CONFIG
 
 /* default window dimensions (overwritten via -g option): */

--- a/main.c
+++ b/main.c
@@ -47,8 +47,6 @@ enum {
 	TITLE_LEN    = 256
 };
 
-#define EXEC_REL_DIR ".sxiv/exec"
-
 enum {
 	EXEC_INFO,
 	EXEC_KEY


### PR DESCRIPTION
Personally, I would like to place the scripts somewhere else so I moved the definition of `EXEC_REL_DIR` to `config.def.h`. I think more users could benefit from this and it won't hurt those who won't.
