### PR TITLE
Timeout initial redraw

### DIFF
--- a/main.c
+++ b/main.c
@@ -644,7 +644,7 @@ void run(void)
 	bool discard, to_set;
 	XEvent ev, nextev;
 
-	redraw();
+	set_timeout(redraw, 25, false);
 
 	while (true) {
 		while (mode == MODE_THUMB && tns.cnt < filecnt &&


### PR DESCRIPTION
I use window manager (XMonad) which modifies sxiv window geometry upon startup.
That causes sxiv redraw the content in respect with original geometry and then right away redraw for new geometry. Result is not easy for eyes. I've fixed it by timing-out initial redraw for a bit.

This improves the behaviour also for standard window managers (tested with Openbox), when starting in fullscreen mode (`sxiv -f`) where fullscreen mode is "turned on" after some small delay. If one wants to be pedantic, delay manifest itself also with flashing of background color (gray to black) and resize from initial to fullscreen. Since it's not my use-case I didn't bother to investigate further—just stating as I've noticed it.

As this simple fix might be of benefit to others, please consider merging.
Thanks
