### PR TITLE
s_strdup take a const char* string.

### DIFF
--- a/util.c
+++ b/util.c
@@ -54,7 +54,7 @@ void* s_realloc(void *ptr, size_t size)
 	return ptr;
 }
 
-char* s_strdup(char *s)
+char* s_strdup(const char *s)
 {
 	char *d = NULL;
 

--- a/util.h
+++ b/util.h
@@ -63,7 +63,7 @@ typedef struct {
 
 void* s_malloc(size_t);
 void* s_realloc(void*, size_t);
-char* s_strdup(char*);
+char* s_strdup(const char*);
 
 void warn(const char*, ...);
 void die(const char*, ...);


### PR DESCRIPTION
s_strdup should take a const string as its arguments, like the POSIX.1-2001 version.
