### PR TITLE
Remove unnecessary null pointer checks.

### DIFF
--- a/main.c
+++ b/main.c
@@ -810,8 +810,7 @@ int main(int argc, char **argv)
 				filename[len-1] = '\0';
 			check_add_file(filename);
 		}
-		if (filename != NULL)
-			free(filename);
+		free(filename);
 	}
 
 	for (i = 0; i < options->filecnt; i++) {

--- a/thumbs.c
+++ b/thumbs.c
@@ -176,8 +176,7 @@ void tns_init(tns_t *tns, const fileinfo_t *files, int cnt, int *sel, win_t *win
 		dsuffix = "/.cache";
 	}
 	if (homedir != NULL) {
-		if (cache_dir != NULL)
-			free(cache_dir);
+		free(cache_dir);
 		len = strlen(homedir) + strlen(dsuffix) + 6;
 		cache_dir = (char*) s_malloc(len);
 		snprintf(cache_dir, len, "%s%s/sxiv", homedir, dsuffix);
@@ -204,10 +203,8 @@ void tns_free(tns_t *tns)
 		tns->thumbs = NULL;
 	}
 
-	if (cache_dir != NULL) {
-		free(cache_dir);
-		cache_dir = NULL;
-	}
+	free(cache_dir);
+	cache_dir = NULL;
 }
 
 bool tns_load(tns_t *tns, int n, bool force)

--- a/util.c
+++ b/util.c
@@ -198,18 +198,13 @@ char* absolute_path(const char *filename)
 	goto end;
 
 error:
-	if (path != NULL) {
-		free(path);
-		path = NULL;
-	}
+	free(path);
+	path = NULL;
 
 end:
-	if (dirname != NULL)
-		free(dirname);
-	if (cwd != NULL)
-		free(cwd);
-	if (twd != NULL)
-		free(twd);
+	free(dirname);
+	free(cwd);
+	free(twd);
 
 	return path;
 }
@@ -254,7 +249,7 @@ int r_closedir(r_dir_t *rdir)
 			rdir->dir = NULL;
 	}
 
-	if (rdir->d != 0 && rdir->name != NULL) {
+	if (rdir->d) {
 		free(rdir->name);
 		rdir->name = NULL;
 	}


### PR DESCRIPTION
[The function "free"](http://pubs.opengroup.org/onlinepubs/9699919799/functions/free.html) performs input parameter validation. It is therefore not needed to check a passed pointer before this function call.

A corresponding update suggestion was generated by [the software "Coccinelle"](http://coccinelle.lip6.fr/) from the following semantic patch approach.

```
@Remove_unnecessary_pointer_checks1@
expression x;
@@
-if (x != \(0 \| NULL\))
    free(x);

@Remove_unnecessary_pointer_checks2@
expression x;
@@
-if (x != \(0 \| NULL\)) {
    free(x);
    x = \(0 \| NULL\);
-}

@Remove_unnecessary_pointer_checks3@
expression a, b;
@@
-if (a != \(0 \| NULL\) && b != \(0 \| NULL\))
+if (a)
    free(b);

@Remove_unnecessary_pointer_checks4@
expression a, b;
@@
-if (a != \(0 \| NULL\) && b != \(0 \| NULL\)) {
+if (a) {
    free(b);
    b = \(0 \| NULL\);
 }
```
