### PR TITLE
Fix Makefile depend file usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ $(OBJ): Makefile config.h
 
 depend: .depend
 
-.depend: $(SRC)
+.depend: $(SRC) config.h
 	rm -f ./.depend
 	$(CC) $(CFLAGS) -MM $^ >./.depend
 
-include .depend
+-include .depend
 
 .c.o:
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DVERSION=\"$(VERSION)\" -c -o $@ $<


### PR DESCRIPTION
Creating the .depend file requires the config.h file to exist and
suppress make's complaints if the .depend file doesn't exist when
initially parsing the makefile.
