### PR TITLE
The Icon key should not contain extension

### DIFF
--- a/sxiv.desktop
+++ b/sxiv.desktop
@@ -5,4 +5,4 @@ GenericName=Image Viewer
 Exec=sxiv %F
 MimeType=image/bmp;image/gif;image/jpeg;image/jpg;image/png;image/tiff;image/x-bmp;
 NoDisplay=true
-Icon=sxiv.png
+Icon=sxiv


### PR DESCRIPTION
According to the official [Icon Theme Spec](http://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#icon_lookup) the Icon key in the desktop entry file should not contain the file extension.