### PR TITLE
Added -R option to randomize slideshow image order

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ of small previews is displayed, making it easy to choose an image to open.
     -o           Write list of marked files to stdout when quitting
     -q           Be quiet, disable warnings
     -r           Search given directories recursively for images
+    -R           Randomize images in slideshow mode
     -S DELAY     Enable slideshow and set slideshow delay to DELAY seconds
     -s MODE      Set scale mode to MODE ([d]own, [f]it, [w]idth, [h]eight)
     -t           Start in thumbnail mode

--- a/options.c
+++ b/options.c
@@ -53,6 +53,7 @@ void parse_options(int argc, char **argv)
 	_options.from_stdin = false;
 	_options.to_stdout = false;
 	_options.recursive = false;
+	_options.randomize = false;
 	_options.startnum = 0;
 
 	_options.scalemode = SCALE_DOWN;
@@ -70,7 +71,7 @@ void parse_options(int argc, char **argv)
 	_options.thumb_mode = false;
 	_options.clean_cache = false;
 
-	while ((opt = getopt(argc, argv, "abcfG:g:hin:N:oqrS:s:tvZz:")) != -1) {
+	while ((opt = getopt(argc, argv, "abcfG:g:hin:N:oqrRS:s:tvZz:")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
@@ -119,6 +120,9 @@ void parse_options(int argc, char **argv)
 				break;
 			case 'r':
 				_options.recursive = true;
+				break;
+			case 'R':
+				_options.randomize = true;
 				break;
 			case 'S':
 				n = strtol(optarg, &end, 0);

--- a/options.h
+++ b/options.h
@@ -28,6 +28,7 @@ typedef struct {
 	bool from_stdin;
 	bool to_stdout;
 	bool recursive;
+	bool randomize;
 	int filecnt;
 	int startnum;
 

--- a/sxiv.1
+++ b/sxiv.1
@@ -74,6 +74,9 @@ Be quiet, disable warnings to standard error stream.
 .B \-r
 Search the given directories recursively for images to view.
 .TP
+.B \-R
+Randomize image order in slideshow mode
+.TP
 .BI "\-S " DELAY
 Start in slideshow mode. Set the delay between images to DELAY seconds.
 .TP


### PR DESCRIPTION
When staring sxiv with -R command-line option and starting slideshow mode,
fileidx of the next image to be loaded will be randomized. This is done using
rand() and thus does not provide cryptographical-strength pseudo-random number
generation, but should nevertheless be good enough for viewing images in
random order.
This does _not_ randomize the file order itself, e.g. when using shortcuts for
next/previous images; doing so would require either (a) randomizing the file
list itself on startup or (b) managing a linked list of the random sequence.
Both options have drawbacks in my point of view.
