### PR TITLE
Added an option to fill alpha channel with solid color. 

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -420,7 +420,7 @@ bool ci_toggle_antialias(arg_t _)
 
 bool ci_toggle_alpha(arg_t _)
 {
-	img.alpha = !img.alpha;
+	img.alpha = (img.alpha + 1) % ALPHA_NUMOPTIONS;
 	img.dirty = true;
 	return true;
 }

--- a/config.def.h
+++ b/config.def.h
@@ -19,6 +19,7 @@ static const char * const WIN_FS_COLOR = "#000000";
 static const char * const SEL_COLOR    = "#EEEEEE";
 static const char * const BAR_BG_COLOR = "#222222";
 static const char * const BAR_FG_COLOR = "#EEEEEE";
+static const char * const ALPHA_COLOR  = "#FFFFFF";
 
 #endif
 #ifdef _IMAGE_CONFIG
@@ -45,10 +46,11 @@ static const int    GAMMA_RANGE = 32;
  */
 static const bool ANTI_ALIAS = true;
 
-/* if true, use a checkerboard background for alpha layer,
+/* use no background (ALPHA_NONE), checkerboard (ALPHA_CHECKERBOARD),
+ * or solid color (ALPHA_SOLID) for alpha layer.
  * toggled with 'A' key binding
  */
-static const bool ALPHA_LAYER = false;
+static const alphamode_t ALPHA_LAYER = ALPHA_NONE;
 
 #endif
 #ifdef _THUMBS_CONFIG

--- a/image.c
+++ b/image.c
@@ -469,7 +469,7 @@ void img_render(img_t *img)
 		imlib_context_set_image(bg);
 		imlib_image_set_has_alpha(0);
 
-		if (img->alpha) {
+		if (img->alpha == ALPHA_CHECKERBOARD) {
 			int i, c, r;
 			DATA32 col[2] = { 0xFF666666, 0xFF999999 };
 			DATA32 * data = imlib_image_get_data();
@@ -484,8 +484,11 @@ void img_render(img_t *img)
 				}
 			}
 			imlib_image_put_back_data(data);
-		} else {
-			c = win->fullscreen ? win->fscol : win->bgcol;
+		} else { // ALPHA_NONE || ALPHA_SOLID
+			if(img->alpha == ALPHA_SOLID)
+				c = win->alphacol;
+			else
+				c = win->fullscreen ? win->fscol : win->bgcol;
 			imlib_context_set_color(c >> 16 & 0xFF, c >> 8 & 0xFF, c & 0xFF, 0xFF);
 			imlib_image_fill_rectangle(0, 0, dw, dh);
 		}

--- a/image.h
+++ b/image.h
@@ -53,7 +53,7 @@ typedef struct {
 	bool checkpan;
 	bool dirty;
 	bool aa;
-	bool alpha;
+	alphamode_t alpha;
 
 	Imlib_Color_Modifier cmod;
 	int gamma;

--- a/types.h
+++ b/types.h
@@ -60,6 +60,13 @@ typedef enum {
 } scalemode_t;
 
 typedef enum {
+	ALPHA_NONE,
+	ALPHA_CHECKERBOARD,
+	ALPHA_SOLID,
+	ALPHA_NUMOPTIONS
+} alphamode_t;
+
+typedef enum {
 	CURSOR_ARROW,
 	CURSOR_NONE,
 	CURSOR_HAND,

--- a/window.c
+++ b/window.c
@@ -162,6 +162,7 @@ void win_init(win_t *win)
 	win->selcol    = win_alloc_color(win, SEL_COLOR);
 	win->bar.bgcol = win_alloc_color(win, BAR_BG_COLOR);
 	win->bar.fgcol = win_alloc_color(win, BAR_FG_COLOR);
+        win->alphacol  = win_alloc_color(win, ALPHA_COLOR);
 
 	win->bar.l.size = BAR_L_LEN;
 	win->bar.r.size = BAR_R_LEN;

--- a/window.h
+++ b/window.h
@@ -62,6 +62,7 @@ typedef struct {
 	unsigned long bgcol;
 	unsigned long fscol;
 	unsigned long selcol;
+        unsigned long alphacol;
 
 	int x;
 	int y;


### PR DESCRIPTION
Set to white per default. This is useful to inspect images with an alpha channel against a solid background, showing detail that might be hidden. I use this for images that are to be included in a publication, for example.

Cycle through the three modes
* No background
* Checkerboard
* Solid background
with the default ALPHA keyboard shortcut.