### PR TITLE
Enable reading images directly from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Features
 * Basic support for multi-frame images
 * Load all frames from GIF files and play GIF animations
 * Display image information in status bar
+* Load images directly from stdin
 
 
 Screenshots

--- a/main.c
+++ b/main.c
@@ -99,6 +99,11 @@ void cleanup(void)
 {
 	img_close(&img, false);
 	tns_free(&tns);
+
+	if (!STREQ(options->tmpfile, tmpfile_template)) {
+		unlink(options->tmpfile);
+	}
+
 	win_close(&win);
 }
 
@@ -783,12 +788,12 @@ int main(int argc, char **argv)
 		exit(EXIT_SUCCESS);
 	}
 
-	if (options->filecnt == 0 && !options->from_stdin) {
+	if (options->filecnt == 0 && !options->names_from_stdin) {
 		print_usage();
 		exit(EXIT_FAILURE);
 	}
 
-	if (options->recursive || options->from_stdin)
+	if (options->recursive || options->names_from_stdin)
 		filecnt = 1024;
 	else
 		filecnt = options->filecnt;
@@ -797,7 +802,7 @@ int main(int argc, char **argv)
 	memset(files, 0, filecnt * sizeof(*files));
 	fileidx = 0;
 
-	if (options->from_stdin) {
+	if (options->names_from_stdin) {
 		n = 0;
 		filename = NULL;
 		while ((len = getline(&filename, &n, stdin)) > 0) {
@@ -810,6 +815,10 @@ int main(int argc, char **argv)
 
 	for (i = 0; i < options->filecnt; i++) {
 		filename = options->filenames[i];
+
+		if (STREQ(filename, "-")) {
+			continue;
+		}
 
 		if (stat(filename, &fstats) < 0) {
 			error(0, errno, "%s", filename);

--- a/options.c
+++ b/options.c
@@ -50,10 +50,11 @@ void parse_options(int argc, char **argv)
 	progname = strrchr(argv[0], '/');
 	progname = progname ? progname + 1 : argv[0];
 
-	_options.from_stdin = false;
+	_options.names_from_stdin = false;
 	_options.to_stdout = false;
 	_options.recursive = false;
 	_options.startnum = 0;
+	strcpy(_options.tmpfile, tmpfile_template);
 
 	_options.scalemode = SCALE_DOWN;
 	_options.zoom = 1.0;
@@ -100,7 +101,7 @@ void parse_options(int argc, char **argv)
 				print_usage();
 				exit(EXIT_SUCCESS);
 			case 'i':
-				_options.from_stdin = true;
+				_options.names_from_stdin = true;
 				break;
 			case 'n':
 				n = strtol(optarg, &end, 0);
@@ -155,9 +156,20 @@ void parse_options(int argc, char **argv)
 	_options.filenames = argv + optind;
 	_options.filecnt = argc - optind;
 
-	if (_options.filecnt == 1 && STREQ(_options.filenames[0], "-")) {
-		_options.filenames++;
-		_options.filecnt--;
-		_options.from_stdin = true;
+	if (_options.filecnt == 0) {
+		if (stdin2tmp(_options.tmpfile) != -1) {
+			_options.filenames[0] = _options.tmpfile;
+			_options.filecnt++;
+		}
+	} else {
+		for (int i = _options.filecnt - 1; i >= 0; i--) {
+			if (STREQ(_options.filenames[i], "-")) {
+				if (stdin2tmp(_options.tmpfile) != -1) {
+					_options.filenames[i] = _options.tmpfile;
+				}
+				break;
+
+			}
+		}
 	}
 }

--- a/options.h
+++ b/options.h
@@ -22,14 +22,18 @@
 #include "types.h"
 #include "image.h"
 
+#define tmpfile_template "/tmp/sxiv_stdinXXXXXX"
+#define tmpfile_len 21
+
 typedef struct {
 	/* file list: */
 	char **filenames;
-	bool from_stdin;
+	bool names_from_stdin;
 	bool to_stdout;
 	bool recursive;
 	int filecnt;
 	int startnum;
+	char tmpfile[tmpfile_len];
 
 	/* image: */
 	scalemode_t scalemode;

--- a/sxiv.1
+++ b/sxiv.1
@@ -19,6 +19,19 @@ sxiv \- Simple X Image Viewer
 .RB [ \-z
 .IR ZOOM ]
 .IR FILE ...
+.P
+.B sxiv
+.RB [ OPTIONS ]
+<
+.I FILE
+.P
+.B sxiv
+.RB [ OPTIONS ]
+.RI [ FILES ] 
+\-
+.RI [ FILES ]
+<
+.I FILE
 .SH DESCRIPTION
 sxiv is a simple image viewer for X. It only has the most basic features
 required for fast image viewing.

--- a/util.c
+++ b/util.c
@@ -204,3 +204,26 @@ int r_mkdir(char *path)
 	}
 	return 0;
 }
+
+int stdin2tmp(char *name)
+{
+	int tmp;
+	char buf[BUFSIZ];
+	int ret = 0;
+
+	if ((tmp = mkstemp(name)) == -1) {
+		perror("mkstemp error");
+		return -1;
+	}
+
+	while (fread(buf, sizeof(char), BUFSIZ, stdin) > 0) {
+		if ((write(tmp, buf, BUFSIZ)) == -1) {
+			perror("fwrite error");
+			ret = -1;
+		}
+	}
+
+	close(tmp);
+	return ret;
+}
+

--- a/util.h
+++ b/util.h
@@ -76,4 +76,11 @@ int r_closedir(r_dir_t*);
 char* r_readdir(r_dir_t*);
 int r_mkdir(char*);
 
+/*
+ * stdin2tmp: copy stdin to a temporary file.
+ * Argument `name' must be acceptable to mkstemp(3).
+ * The resulting temporary file is unlinked during cleanup().
+ */
+int stdin2tmp(char *);
+
 #endif /* UTIL_H */


### PR DESCRIPTION
sxiv -i < list_of_images: read list of files from stdin (unchanged)
sxiv < image: display image
sxiv - < image: display image
sxiv picture - snapshot < image: display picture, image, snapshot
sxiv - picture - snapshot - photo < image:
	display picture, snapshot, image, photo; ignore other '-'s