### PR TITLE
Always pass marked images to stdin of key-handler

### DIFF
--- a/exec/key-handler
+++ b/exec/key-handler
@@ -2,9 +2,9 @@
 
 # Example for $XDG_CONFIG_HOME/sxiv/exec/key-handler
 # Called by sxiv(1) after the external prefix key (C-x by default) is pressed.
-# The next key combo is passed as its first argument. Passed via stdin are the
-# images to act upon, one path per line: all marked images, if in thumbnail
-# mode and at least one image has been marked, otherwise the current image.
+# The next key combo is passed as its first argument. The path to the current
+# image is passed as its second argument. The paths to all marked images are
+# passed via stdin, one per line.
 # sxiv(1) blocks until this script terminates. It then checks which images
 # have been modified and reloads them.
 

--- a/sxiv.1
+++ b/sxiv.1
@@ -377,9 +377,9 @@ located in
 .IR $XDG_CONFIG_HOME/sxiv/exec/key-handler .
 The handler is invoked by pressing
 .BR Ctrl-x .
-The next key combo is passed as its first argument. Passed via stdin are the
-images to act upon, one path per line: all marked images, if in thumbnail mode
-and at least one image has been marked, otherwise the current image.
+The next key combo is passed as its first argument. The path to the current
+image is passed as its second argument. The paths to all marked images are
+passed via stdin, one per line.
 sxiv(1) will block until the handler terminates. It then checks which images
 have been modified and reloads them.
 


### PR DESCRIPTION
This simplifies the logic, and removes ambiguity WRT what is passed.
The current image is always passed as the second argument.

It's no more required to switch to thumbnail mode, and therefore to
trigger caching, in order to pass the list of marked images.

#249 