### PR TITLE
Add option to specify playback frame rate of animated images

### DIFF
--- a/image.c
+++ b/image.c
@@ -68,6 +68,7 @@ void img_init(img_t *img, win_t *win)
 	img->alpha = ALPHA_LAYER;
 	img->multi.cap = img->multi.cnt = 0;
 	img->multi.animate = options->animate;
+	img->multi.framedelay = options->framerate > 0 ? 1000 / options->framerate : 0;
 	img->multi.length = 0;
 
 	img->cmod = imlib_create_color_modifier();
@@ -263,6 +264,7 @@ bool img_load_gif(img_t *img, const fileinfo_t *file)
 				                             img->multi.cap * sizeof(img_frame_t));
 			}
 			img->multi.frames[img->multi.cnt].im = im;
+			delay = img->multi.framedelay > 0 ? img->multi.framedelay : delay;
 			img->multi.frames[img->multi.cnt].delay = delay > 0 ? delay : DEF_GIF_DELAY;
 			img->multi.length += img->multi.frames[img->multi.cnt].delay;
 			img->multi.cnt++;

--- a/image.h
+++ b/image.h
@@ -35,6 +35,7 @@ typedef struct {
 	int cnt;
 	int sel;
 	bool animate;
+	int framedelay;
 	int length;
 } multi_img_t;
 

--- a/options.c
+++ b/options.c
@@ -32,7 +32,7 @@ const options_t *options = (const options_t*) &_options;
 
 void print_usage(void)
 {
-	printf("usage: sxiv [-abcfhioqrtvZ] [-e WID] [-G GAMMA] [-g GEOMETRY] "
+	printf("usage: sxiv [-abcfhioqrtvZ] [-A FRAMERATE] [-e WID] [-G GAMMA] [-g GEOMETRY] "
 	       "[-N NAME] [-n NUM] [-S DELAY] [-s MODE] [-z ZOOM] FILES...\n");
 }
 
@@ -60,6 +60,7 @@ void parse_options(int argc, char **argv)
 	_options.animate = false;
 	_options.gamma = 0;
 	_options.slideshow = 0;
+	_options.framerate = 0;
 
 	_options.fullscreen = false;
 	_options.embed = 0;
@@ -71,13 +72,20 @@ void parse_options(int argc, char **argv)
 	_options.thumb_mode = false;
 	_options.clean_cache = false;
 
-	while ((opt = getopt(argc, argv, "abce:fG:g:hin:N:oqrS:s:tvZz:")) != -1) {
+	while ((opt = getopt(argc, argv, "aA:bce:fG:g:hin:N:oqrS:s:tvZz:")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
 				exit(EXIT_FAILURE);
 			case 'a':
 				_options.animate = true;
+				break;
+			case 'A':
+				_options.animate = true;
+				n = strtol(optarg, &end, 0);
+				if (*end != '\0' || n <= 0)
+					error(EXIT_FAILURE, 0, "Invalid argument for option -A: %s", optarg);
+				_options.framerate = n;
 				break;
 			case 'b':
 				_options.hide_bar = true;

--- a/options.h
+++ b/options.h
@@ -37,6 +37,7 @@ typedef struct {
 	bool animate;
 	int gamma;
 	int slideshow;
+	int framerate;
 
 	/* window: */
 	bool fullscreen;

--- a/sxiv.1
+++ b/sxiv.1
@@ -4,6 +4,8 @@ sxiv \- Simple X Image Viewer
 .SH SYNOPSIS
 .B sxiv
 .RB [ \-abcfhioqrtvZ ]
+.RB [ \-A
+.IR FRAMERATE ]
 .RB [ \-e
 .IR WID ]
 .RB [ \-G
@@ -35,6 +37,9 @@ manager.
 .TP
 .B \-a
 Play animations of multi-frame images.
+.TP
+.BI "\-A " FRAMERATE
+Force frame rate on animated images to FRAMERATE
 .TP
 .B \-b
 Do not show info bar on bottom of window.


### PR DESCRIPTION
Sometimes gif-makers don't include frame delay information, and the configured default isn't necessarily one-size-fits-all. (Or the maker chose a bad rate.) In those cases it's nice to be able to force animation at a specific rate.