### PR TITLE
Add build options for optional dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,15 @@ LIBS      := -lImlib2 -lX11 -lXft
 
 # optional dependencies:
 # giflib: gif animations
+ifeq ($(WITH_GIFLIB), 1)
 	CPPFLAGS += -DHAVE_GIFLIB
 	LIBS     += -lgif
+endif
 # libexif: jpeg auto-orientation, exif thumbnails
+ifeq ($(WITH_LIBEXIF), 1)
 	CPPFLAGS += -DHAVE_LIBEXIF
 	LIBS     += -lexif
-
+endif
 
 .PHONY: clean install uninstall
 


### PR DESCRIPTION
This is to add simple *make magic* to be able to build sxiv with or without optional dependencies like this:

```
make WITH_GIFLIB=1 WITH_LIBEXIF=1
```