### PR TITLE
Add a flag to disable thumbnail caching

### DIFF
--- a/options.c
+++ b/options.c
@@ -32,7 +32,7 @@ const options_t *options = (const options_t*) &_options;
 
 void print_usage(void)
 {
-	printf("usage: sxiv [-abcfhioqrtvZ] [-A FRAMERATE] [-e WID] [-G GAMMA] "
+	printf("usage: sxiv [-abcfhioqrtvUZ] [-A FRAMERATE] [-e WID] [-G GAMMA] "
 	       "[-g GEOMETRY] [-N NAME] [-n NUM] [-S DELAY] [-s MODE] [-z ZOOM] "
 	       "FILES...\n");
 }
@@ -72,8 +72,9 @@ void parse_options(int argc, char **argv)
 	_options.quiet = false;
 	_options.thumb_mode = false;
 	_options.clean_cache = false;
+	_options.allow_cache_write = true;
 
-	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:oqrS:s:tvZz:")) != -1) {
+	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:oqrS:s:tvUZz:")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
@@ -153,6 +154,9 @@ void parse_options(int argc, char **argv)
 			case 'v':
 				print_version();
 				exit(EXIT_SUCCESS);
+			case 'U':
+				_options.allow_cache_write = false;
+				break;
 			case 'Z':
 				_options.scalemode = SCALE_ZOOM;
 				_options.zoom = 1.0;

--- a/options.c
+++ b/options.c
@@ -32,7 +32,7 @@ const options_t *options = (const options_t*) &_options;
 
 void print_usage(void)
 {
-	printf("usage: sxiv [-abcfhioqrtvUZ] [-A FRAMERATE] [-e WID] [-G GAMMA] "
+	printf("usage: sxiv [-abcfhiopqrtvZ] [-A FRAMERATE] [-e WID] [-G GAMMA] "
 	       "[-g GEOMETRY] [-N NAME] [-n NUM] [-S DELAY] [-s MODE] [-z ZOOM] "
 	       "FILES...\n");
 }
@@ -74,7 +74,7 @@ void parse_options(int argc, char **argv)
 	_options.clean_cache = false;
 	_options.allow_cache_write = true;
 
-	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:oqrS:s:tvUZz:")) != -1) {
+	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:opqrS:s:tvZz:")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
@@ -130,6 +130,9 @@ void parse_options(int argc, char **argv)
 			case 'o':
 				_options.to_stdout = true;
 				break;
+			case 'p':
+				_options.allow_cache_write = false;
+				break;
 			case 'q':
 				_options.quiet = true;
 				break;
@@ -154,9 +157,6 @@ void parse_options(int argc, char **argv)
 			case 'v':
 				print_version();
 				exit(EXIT_SUCCESS);
-			case 'U':
-				_options.allow_cache_write = false;
-				break;
 			case 'Z':
 				_options.scalemode = SCALE_ZOOM;
 				_options.zoom = 1.0;

--- a/options.h
+++ b/options.h
@@ -50,6 +50,7 @@ typedef struct {
 	bool quiet;
 	bool thumb_mode;
 	bool clean_cache;
+	bool allow_cache_write;
 } options_t;
 
 extern const options_t *options;

--- a/thumbs.c
+++ b/thumbs.c
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #include <utime.h>
 
+#include "options.h"
 #include "thumbs.h"
 #include "util.h"
 
@@ -82,6 +83,9 @@ void tns_cache_write(Imlib_Image im, const char *filepath, bool force)
 	struct stat cstats, fstats;
 	struct utimbuf times;
 	Imlib_Load_Error err = 0;
+
+	if (!options->allow_cache_write)
+		return;
 
 	if (stat(filepath, &fstats) < 0)
 		return;


### PR DESCRIPTION
Closes #285.

To do:

 - [x] Use `-p` instead.
 - [x] Update the man page. (I forgot. I also don't know the format.)
 - [x] Also disable writes done by `tns_load`