### PR TITLE
Add fast selection functionality

### DIFF
--- a/exec/key-handler
+++ b/exec/key-handler
@@ -47,6 +47,8 @@ case "$KEY" in
 "y")        tr '\n' ' ' | xclip -i ;;
 "C-c")      while read file; do xclip -selection clipboard -target image/png "$file"; done ;;
 "C-e")      while read file; do urxvt -bg "#444" -fg "#eee" -sl 0 -title "$file" -e sh -c "exiv2 pr -q -pa '$file' | less" & done ;;
+"C-s")      if [ ! -d "selection" ]; then mkdir "selection"; fi; cp "$file" "./selection/"$(basename "$file");;
+"C-u")      if [ -e "./selection/$(basename "$file")" ]; then rm "./selection/$(basename "$file")"; fi;;
 "C-g")      tr '\n' '\0' | xargs -0 gimp & ;;
 "C-comma")  rotate 270 ;;
 "C-period") rotate  90 ;;


### PR DESCRIPTION
With that addition you can make a photo selection of your large image folder very fast. Predominant useful for photographers with with a lot of photos from the same scene or burst shots. Just by tabbing through your photos you can create a subset of the best and sharp ones.

Pressing `ctrl + x` (to activate the key handler) and then `ctrl + s` creates an folder called `selection` if it is not already present. In addition it copies the current shown image to the selection folder.
Pressing `ctrl + x` (to activate the key handler) and then `ctrl + u` removes the current shown image from the selection folder.
