### PR TITLE
Try to match a fallback font if needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ LIB_EXIF_0 =
 LIB_EXIF_1 = -lexif
 LIB_GIF_0 =
 LIB_GIF_1 = -lgif
-LDLIBS = -lImlib2 -lX11 -lXft \
+LDLIBS = -lImlib2 -lX11 -lXft -lfontconfig \
   $(LIB_EXIF_$(HAVE_LIBEXIF)) $(LIB_GIF_$(HAVE_GIFLIB))
 
 OBJS = autoreload_$(AUTORELOAD).o commands.o image.o main.o options.o \

--- a/main.c
+++ b/main.c
@@ -390,8 +390,8 @@ void update_info(void)
 	if (ow_info) {
 		fn = strlen(files[fileidx].name);
 		if (fn < l->size &&
-		    win_textwidth(&win.env, files[fileidx].name, fn, true) +
-		    win_textwidth(&win.env, r->buf, r->p - r->buf, true) < win.w)
+		    win_textwidth(&win.env, files[fileidx].name, fn, true, NULL) +
+		    win_textwidth(&win.env, r->buf, r->p - r->buf, true, NULL) < win.w)
 		{
 			strncpy(l->buf, files[fileidx].name, l->size);
 		} else {

--- a/sxiv.h
+++ b/sxiv.h
@@ -362,6 +362,7 @@ int r_opendir(r_dir_t*, const char*, bool);
 int r_closedir(r_dir_t*);
 char* r_readdir(r_dir_t*);
 int r_mkdir(char*);
+void* utf8codepoint(const void * __restrict__ str, long * __restrict__ out_codepoint);
 
 
 /* window.c */
@@ -442,7 +443,7 @@ void win_toggle_bar(win_t*);
 void win_clear(win_t*);
 void win_draw(win_t*);
 void win_draw_rect(win_t*, int, int, int, int, bool, int, unsigned long);
-int win_textwidth(const win_env_t*, const char*, unsigned int, bool);
+int win_textwidth(const win_env_t*, const char*, unsigned int, bool, XftFont*);
 void win_set_title(win_t*, const char*);
 void win_set_cursor(win_t*, cursor_t);
 void win_cursor_pos(win_t*, int*, int*);

--- a/sxiv.h
+++ b/sxiv.h
@@ -362,7 +362,7 @@ int r_opendir(r_dir_t*, const char*, bool);
 int r_closedir(r_dir_t*);
 char* r_readdir(r_dir_t*);
 int r_mkdir(char*);
-void* utf8codepoint(const void * __restrict__ str, long * __restrict__ out_codepoint);
+int utf8codepoint(const void * __restrict__, long * __restrict__);
 
 
 /* window.c */

--- a/util.c
+++ b/util.c
@@ -204,3 +204,32 @@ int r_mkdir(char *path)
 	}
 	return 0;
 }
+
+/* copied from sheredom's utf8.h (public domain) https://github.com/sheredom/utf8.h */
+
+void* utf8codepoint(const void* __restrict__ str, long* __restrict__ out_codepoint)
+{
+	 const char *s = (const char *)str;
+
+	 if (0xf0 == (0xf8 & s[0])) {
+		// 4 byte utf8 codepoint
+		*out_codepoint = ((0x07 & s[0]) << 18) | ((0x3f & s[1]) << 12) |
+				 ((0x3f & s[2]) << 6) | (0x3f & s[3]);
+		s += 4;
+	} else if (0xe0 == (0xf0 & s[0])) {
+		// 3 byte utf8 codepoint
+		*out_codepoint = ((0x0f & s[0]) << 12) | ((0x3f & s[1]) << 6) | (0x3f & s[2]);
+		s += 3;
+	} else if (0xc0 == (0xe0 & s[0])) {
+		// 2 byte utf8 codepoint
+		*out_codepoint = ((0x1f & s[0]) << 6) | (0x3f & s[1]);
+		s += 2;
+	} else {
+		// 1 byte utf8 codepoint otherwise
+		*out_codepoint = s[0];
+		s += 1;
+	}
+
+	return (void *)s;
+}
+

--- a/util.c
+++ b/util.c
@@ -205,9 +205,9 @@ int r_mkdir(char *path)
 	return 0;
 }
 
-/* copied from sheredom's utf8.h (public domain) https://github.com/sheredom/utf8.h */
+/* adapted from sheredom's utf8.h (public domain) https://github.com/sheredom/utf8.h */
 
-void* utf8codepoint(const void* __restrict__ str, long* __restrict__ out_codepoint)
+int utf8codepoint(const void* __restrict__ str, long* __restrict__ out_codepoint)
 {
 	 const char *s = (const char *)str;
 
@@ -215,21 +215,18 @@ void* utf8codepoint(const void* __restrict__ str, long* __restrict__ out_codepoi
 		// 4 byte utf8 codepoint
 		*out_codepoint = ((0x07 & s[0]) << 18) | ((0x3f & s[1]) << 12) |
 				 ((0x3f & s[2]) << 6) | (0x3f & s[3]);
-		s += 4;
+		return 4;
 	} else if (0xe0 == (0xf0 & s[0])) {
 		// 3 byte utf8 codepoint
 		*out_codepoint = ((0x0f & s[0]) << 12) | ((0x3f & s[1]) << 6) | (0x3f & s[2]);
-		s += 3;
+		return 3;
 	} else if (0xc0 == (0xe0 & s[0])) {
 		// 2 byte utf8 codepoint
 		*out_codepoint = ((0x1f & s[0]) << 6) | (0x3f & s[1]);
-		s += 2;
+		return 2;
 	} else {
 		// 1 byte utf8 codepoint otherwise
 		*out_codepoint = s[0];
-		s += 1;
+		return 1;
 	}
-
-	return (void *)s;
 }
-


### PR DESCRIPTION
Fixes #276

Instead of rendering the entire filename at once, Xft will let us do it
character by character. This will allow sxiv to query fontconfig for
a font that can provide any missing codepoints, if needed.

A known issue of this patch is that the "..." dots rendering will not
work properly for very long multibyte filenames. That is because we
cannot easily predict the final width of the rendered filename before
drawing it. I couldn't figure out a clean way to deal with this, so I
ended up just truncating the offending filenames.

I hope that this patch is up to your standards!