### PR TITLE
Avoid to (infinitely) call select() when built with AUTORELOAD=nop

### DIFF
--- a/autoreload_nop.c
+++ b/autoreload_nop.c
@@ -20,7 +20,7 @@
 
 void arl_init(arl_t *arl)
 {
-	(void) arl;
+	arl->fd = -1;
 }
 
 void arl_cleanup(arl_t *arl)


### PR DESCRIPTION
When sxiv is built with AUTORELOAD=nop if something is feed via the stdin it
will start to infinitely calls select() leading to a 100% CPU usage.

Thanks to @sdx23 for helping in analyzing that problem!

Fixes issue #297.