### PR TITLE
add option to sorting files in directories with version sort.

### DIFF
--- a/main.c
+++ b/main.c
@@ -796,11 +796,6 @@ void run(void)
 	}
 }
 
-int fncmp(const void *a, const void *b)
-{
-	return strcoll(((fileinfo_t*) a)->name, ((fileinfo_t*) b)->name);
-}
-
 void sigchld(int sig)
 {
 	while (waitpid(-1, NULL, WNOHANG) > 0);
@@ -886,7 +881,8 @@ int main(int argc, char **argv)
 			}
 			r_closedir(&dir);
 			if (fileidx - start > 1)
-				qsort(files + start, fileidx - start, sizeof(fileinfo_t), fncmp);
+				qsort(files + start, fileidx - start,
+				      sizeof(fileinfo_t), options->filecmp);
 		}
 	}
 

--- a/options.c
+++ b/options.c
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with sxiv.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define _GNU_SOURCE
 #include "sxiv.h"
 #define _IMAGE_CONFIG
 #include "config.h"
@@ -40,6 +40,17 @@ void print_version(void)
 	puts("sxiv " VERSION);
 }
 
+static
+int alpha_fncmp(const void *a, const void *b)
+{
+	return strcoll(((fileinfo_t*) a)->name, ((fileinfo_t*) b)->name);
+}
+static
+int version_fncmp(const void*a, const void* b)
+{
+	return strverscmp(((fileinfo_t*) a)->name, ((fileinfo_t*) b)->name);
+}
+
 void parse_options(int argc, char **argv)
 {
 	int n, opt;
@@ -53,6 +64,7 @@ void parse_options(int argc, char **argv)
 	_options.to_stdout = false;
 	_options.recursive = false;
 	_options.startnum = 0;
+	_options.filecmp = alpha_fncmp;
 
 	_options.scalemode = SCALE_DOWN;
 	_options.zoom = 1.0;
@@ -72,7 +84,7 @@ void parse_options(int argc, char **argv)
 	_options.clean_cache = false;
 	_options.private_mode = false;
 
-	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:opqrS:s:tvZz:")) != -1) {
+	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:opqrS:s:tvVZz:")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
@@ -155,6 +167,9 @@ void parse_options(int argc, char **argv)
 			case 'v':
 				print_version();
 				exit(EXIT_SUCCESS);
+			case 'V':
+				_options.filecmp = version_fncmp;
+				break;
 			case 'Z':
 				_options.scalemode = SCALE_ZOOM;
 				_options.zoom = 1.0;

--- a/sxiv.h
+++ b/sxiv.h
@@ -264,6 +264,7 @@ struct opt {
 	bool recursive;
 	int filecnt;
 	int startnum;
+	int (*filecmp)(const void*, const void*);
 
 	/* image: */
 	scalemode_t scalemode;


### PR DESCRIPTION
A much lighter patch to add support for sorting files in directories with version sort. (i had wrote a [different version using scandir](https://github.com/taiyu-len/sxiv/tree/versionsort), before realizing i could do it much easier this way)

adds new option `-V` which sets sorting function to use `strverscmp`
default sort function is still done via `strcoll`

if theres interest in merging this, theres still the need for adding the flag to the manpage,
as well as making a compile time option to enable it due to strverscmp being a non standard gnu extension.

i did see an issue on this (#229) but it was closd a few years ago it seems.
