### PR TITLE
Added support for webp image files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,24 @@ HAVE_GIFLIB = 1
 # enable features requiring libexif (-lexif)
 HAVE_LIBEXIF = 1
 
+# enable features requiring libwebp (-lwebp)
+HAVE_LIBWEBP = 1
+
 cflags = -std=c99 -Wall -pedantic $(CFLAGS)
 cppflags = -I. $(CPPFLAGS) -D_XOPEN_SOURCE=700 \
   -DHAVE_GIFLIB=$(HAVE_GIFLIB) -DHAVE_LIBEXIF=$(HAVE_LIBEXIF) \
+  -DHAVE_LIBWEBP=$(HAVE_LIBWEBP) \
   -I/usr/include/freetype2 -I$(PREFIX)/include/freetype2
 
 lib_exif_0 =
 lib_exif_1 = -lexif
 lib_gif_0 =
 lib_gif_1 = -lgif
+lib_webp_0 =
+lib_webp_1 = -lwebp -lwebpdemux
 ldlibs = $(LDLIBS) -lImlib2 -lX11 -lXft -lfontconfig \
-  $(lib_exif_$(HAVE_LIBEXIF)) $(lib_gif_$(HAVE_GIFLIB))
+  $(lib_exif_$(HAVE_LIBEXIF)) $(lib_gif_$(HAVE_GIFLIB)) \
+  $(lib_webp_$(HAVE_LIBWEBP))
 
 objs = autoreload_$(AUTORELOAD).o commands.o image.o main.o options.o \
   thumbs.o util.o window.o

--- a/sxiv.desktop
+++ b/sxiv.desktop
@@ -3,6 +3,6 @@ Type=Application
 Name=sxiv
 GenericName=Image Viewer
 Exec=sxiv %F
-MimeType=image/bmp;image/gif;image/jpeg;image/jpg;image/png;image/tiff;image/x-bmp;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-tga;image/x-xpixmap;
+MimeType=image/bmp;image/gif;image/jpeg;image/jpg;image/png;image/tiff;image/x-bmp;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-tga;image/x-xpixmap;image/webp;
 NoDisplay=true
 Icon=sxiv


### PR DESCRIPTION
I added support for viewing WebP image files using libwebp. Animation is implemented based on the existing GIF support. I have tested this with versions 0.5.2 and 1.0.2 of libwebp (the --enable-libwebpdemux configure option is required if building libwebp from source).