### PR TITLE
Match fallback font FC_SIZE to original font

### DIFF
--- a/window.c
+++ b/window.c
@@ -48,6 +48,7 @@ static GC gc;
 
 static XftFont *font;
 static int fontheight;
+static double fontsize;
 static int barheight;
 
 Atom atoms[ATOM_COUNT];
@@ -60,6 +61,7 @@ void win_init_font(const win_env_t *e, const char *fontstr)
 	if ((font = XftFontOpenName(e->dpy, e->scr, fontstr)) == NULL)
 		error(EXIT_FAILURE, 0, "Error loading font '%s'", fontstr);
 	fontheight = font->ascent + font->descent;
+	FcPatternGetDouble(font->pattern, FC_SIZE, 0, &fontsize);
 	barheight = fontheight + 2 * V_TEXT_PAD;
 }
 
@@ -414,7 +416,8 @@ int win_draw_text(win_t *win, XftDraw *d, const XftColor *color, int x, int y,
 			fccharset = FcCharSetCreate();
 			FcCharSetAddChar(fccharset, rune);
 			f = XftFontOpen(win->env.dpy, win->env.scr, FC_CHARSET, FcTypeCharSet,
-			                fccharset, FC_SCALABLE, FcTypeBool, FcTrue, NULL);
+			                fccharset, FC_SCALABLE, FcTypeBool, FcTrue,
+			                FC_SIZE, FcTypeDouble, fontsize, NULL);
 			FcCharSetDestroy(fccharset);
 		}
 		XftTextExtentsUtf8(win->env.dpy, f, (XftChar8*)t, next - t, &ext);


### PR DESCRIPTION
Fallback glyphs currently don't match the size of the original font, leading to them potentially being larger than the bar.

Before:
![1](https://user-images.githubusercontent.com/47908676/53281236-52771700-36f3-11e9-9065-dfd5b8ef6229.png)
![3](https://user-images.githubusercontent.com/47908676/53281234-51de8080-36f3-11e9-9079-e1882d78cdbe.png)

After:
![2](https://user-images.githubusercontent.com/47908676/53281235-52771700-36f3-11e9-8699-30cba4a3d720.png)
![4](https://user-images.githubusercontent.com/47908676/53281233-51de8080-36f3-11e9-97dd-d328272f108b.png)
