### PR TITLE
Print list of marked files in selected order when using -o

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -82,7 +82,7 @@ bool cg_quit(arg_t _)
 		qsort(outfs, filecnt, sizeof *outfs, &cmp_outf_t);
 		for (i = 0; i < filecnt; i++) {
 			if (outfs[i].order != 0)
-				printf("%s %u\n", outfs[i].path, outfs[i].order);
+				printf("%s %u\n", outfs[i].path);
 		}
 	}
 	exit(EXIT_SUCCESS);

--- a/commands.c
+++ b/commands.c
@@ -75,19 +75,21 @@ bool cg_quit(arg_t _)
 
 	if (options->to_stdout && markcnt > 0) {
 		typedef struct {
-			char path;
+			char *path;
 			int order;
 		} outf_t;
+		outf_t *outfs;
+		outfs = emalloc(filecnt * sizeof(outf_t));
 
 		for (i = 0; i < filecnt; i++) {
-			printf("%u,", selects[i]);
+			outfs[i].path = files[i].path;
+			outfs[i].order = selects[i];
 			/*
 			if (files[i].flags & FF_MARK)
 				printf("%s\n", files[i].name);
 				*/
-
+			printf("%s %u\n", outfs[i].path, outfs[i].order);
 		}
-		printf("\n");
 		//qsort(selects, filecnt, sizeof *selects, &compare_ints);
 	}
 	exit(EXIT_SUCCESS);

--- a/commands.c
+++ b/commands.c
@@ -52,15 +52,43 @@ extern int markidx;
 extern int prefix;
 extern bool extprefix;
 
+extern int *selects;
+
+/* Comparison function. Receives two generic (void) pointers to the items under comparison. */
+int compare_ints(const void *p, const void *q) {
+    int x = *(const int *)p;
+    int y = *(const int *)q;
+
+    /* Avoid return x - y, which can cause undefined behaviour
+       because of signed integer overflow. */
+    if (x < y)
+        return -1;  // Return -1 if you want ascending, 1 if you want descending order. 
+    else if (x > y)
+        return 1;   // Return 1 if you want ascending, -1 if you want descending order. 
+
+    return 0;
+}
+
 bool cg_quit(arg_t _)
 {
 	unsigned int i;
 
 	if (options->to_stdout && markcnt > 0) {
+		typedef struct {
+			char path;
+			int order;
+		} outf_t;
+
 		for (i = 0; i < filecnt; i++) {
+			printf("%u,", selects[i]);
+			/*
 			if (files[i].flags & FF_MARK)
 				printf("%s\n", files[i].name);
+				*/
+
 		}
+		printf("\n");
+		//qsort(selects, filecnt, sizeof *selects, &compare_ints);
 	}
 	exit(EXIT_SUCCESS);
 }

--- a/commands.c
+++ b/commands.c
@@ -82,7 +82,7 @@ bool cg_quit(arg_t _)
 		qsort(outfs, filecnt, sizeof *outfs, &cmp_outf_t);
 		for (i = 0; i < filecnt; i++) {
 			if (outfs[i].order != 0)
-				printf("%s %u\n", outfs[i].path);
+				printf("%s\n", outfs[i].path);
 		}
 	}
 	exit(EXIT_SUCCESS);

--- a/commands.c
+++ b/commands.c
@@ -54,18 +54,15 @@ extern bool extprefix;
 
 extern int *selects;
 
-/* Comparison function. Receives two generic (void) pointers to the items under comparison. */
-int compare_ints(const void *p, const void *q) {
-    int x = *(const int *)p;
-    int y = *(const int *)q;
+/* Bad place for this method? */
+int cmp_outf_t(const void *p, const void *q) {
+    outf_t a = *(const outf_t *) p;
+    outf_t b = *(const outf_t *) q;
 
-    /* Avoid return x - y, which can cause undefined behaviour
-       because of signed integer overflow. */
-    if (x < y)
-        return -1;  // Return -1 if you want ascending, 1 if you want descending order. 
-    else if (x > y)
-        return 1;   // Return 1 if you want ascending, -1 if you want descending order. 
-
+    if (a.order < b.order)
+        return -1;
+    else if (a.order > b.order)
+        return 1;
     return 0;
 }
 
@@ -74,23 +71,19 @@ bool cg_quit(arg_t _)
 	unsigned int i;
 
 	if (options->to_stdout && markcnt > 0) {
-		typedef struct {
-			char *path;
-			int order;
-		} outf_t;
 		outf_t *outfs;
 		outfs = emalloc(filecnt * sizeof(outf_t));
-
 		for (i = 0; i < filecnt; i++) {
 			outfs[i].path = files[i].path;
 			outfs[i].order = selects[i];
-			/*
-			if (files[i].flags & FF_MARK)
-				printf("%s\n", files[i].name);
-				*/
-			printf("%s %u\n", outfs[i].path, outfs[i].order);
 		}
-		//qsort(selects, filecnt, sizeof *selects, &compare_ints);
+
+		/* Sort selections in order */
+		qsort(outfs, filecnt, sizeof *outfs, &cmp_outf_t);
+		for (i = 0; i < filecnt; i++) {
+			if (outfs[i].order != 0)
+				printf("%s %u\n", outfs[i].path, outfs[i].order);
+		}
 	}
 	exit(EXIT_SUCCESS);
 }

--- a/main.c
+++ b/main.c
@@ -321,7 +321,7 @@ void load_image(int new)
 		reset_timeout(animate);
 }
 
-int *selects; /* 0 if unselected */
+int *selects; /* 0 if file is unselected */
 int selnext; /* Only incremements by 1. */
 
 bool mark_image(int n, bool on)

--- a/main.c
+++ b/main.c
@@ -326,7 +326,6 @@ int selnext; /* Only incremements by 1. */
 
 bool mark_image(int n, bool on)
 {
-	printf(on ? "true\n" : "false\n");
 	selects[n] = on ? selnext++ : 0;
 
 	markidx = n;

--- a/main.c
+++ b/main.c
@@ -64,6 +64,9 @@ bool extprefix;
 
 bool resized = false;
 
+int *selects; /* 0 if file is unselected */
+int selnext; /* Only incremements by 1. */
+
 typedef struct {
 	int err;
 	char *cmd;
@@ -320,9 +323,6 @@ void load_image(int new)
 	else
 		reset_timeout(animate);
 }
-
-int *selects; /* 0 if file is unselected */
-int selnext; /* Only incremements by 1. */
 
 bool mark_image(int n, bool on)
 {

--- a/main.c
+++ b/main.c
@@ -321,8 +321,14 @@ void load_image(int new)
 		reset_timeout(animate);
 }
 
+int *selects; /* 0 if unselected */
+int selnext; /* Only incremements by 1. */
+
 bool mark_image(int n, bool on)
 {
+	printf(on ? "true\n" : "false\n");
+	selects[n] = on ? selnext++ : 0;
+
 	markidx = n;
 	if (!!(files[n].flags & FF_MARK) != on) {
 		files[n].flags ^= FF_MARK;
@@ -853,6 +859,9 @@ int main(int argc, char **argv)
 	files = emalloc(filecnt * sizeof(*files));
 	memset(files, 0, filecnt * sizeof(*files));
 	fileidx = 0;
+
+	selects = emalloc(filecnt * sizeof(int));
+	selnext = 1;
 
 	if (options->from_stdin) {
 		n = 0;

--- a/sxiv.h
+++ b/sxiv.h
@@ -121,6 +121,11 @@ typedef struct {
 	fileflags_t flags;
 } fileinfo_t;
 
+typedef struct {
+	char *path;
+	int order; /* selects */
+} outf_t;
+
 /* timeouts in milliseconds: */
 enum {
 	TO_REDRAW_RESIZE = 75,


### PR DESCRIPTION
For: #362 

Instead of printing in alphabetical order every time, I made it so that `-o` prints in order of selection. This allows you to do things like:

`sxiv -o scanned/*png | tar -czf readings.tar -T -`

Or

`sxiv -o sprites/*png | gifmaker -`