### PR TITLE
Add FIFO/pipe support

### DIFF
--- a/sxiv.h
+++ b/sxiv.h
@@ -366,6 +366,8 @@ int r_opendir(r_dir_t*, const char*, bool);
 int r_closedir(r_dir_t*);
 char* r_readdir(r_dir_t*, bool);
 int r_mkdir(char*);
+char* tmp_pipe_drain(char*);
+CLEANUP void tmp_unlink(char**, int);
 
 
 /* window.c */


### PR DESCRIPTION
Most shells have some really useful pipe-based redirection. For example (bash), it would be nice to have support for the following in sxiv:

```bash
$ sxiv <(curl -s https://i.imgur.com/JdfIbt4g.png) <(curl -s https://i.imgur.com/WwcW92d.png)
$ curl -s https://i.imgur.com/JdfIbt4g.png | sxiv /dev/stdin
```

This is currently not possible because FIFO/pipe files are not `seek`-able and that breaks things. To solve this, I've drained the pipe to a temporary regular file. This file is displayed and unlinked at exit.