### PR TITLE
Fix a memory leak occuring whenever win_res() is called

### DIFF
--- a/window.c
+++ b/window.c
@@ -73,21 +73,24 @@ void win_alloc_color(const win_env_t *e, const char *name, XftColor *col)
 
 const char* win_res(Display *dpy, const char *name, const char *def)
 {
-	char *type;
-	XrmValue ret;
-	XrmDatabase db;
-	char *res_man;
+	char *type = NULL;
+	XrmValue ret = { .size = 0, .addr = NULL };
+	static XrmDatabase db = NULL;
+	static char *res_man = NULL;
 
-	XrmInitialize();
-
-	if ((res_man = XResourceManagerString(dpy)) != NULL &&
-	    (db = XrmGetStringDatabase(res_man)) != NULL &&
-	    XrmGetResource(db, name, name, &type, &ret) && STREQ(type, "String"))
-	{
-		return ret.addr;
-	} else {
-		return def;
+	if (res_man == NULL) {
+		XrmInitialize();
+		res_man = XResourceManagerString(dpy);
+		if (res_man != NULL) {
+			db = XrmGetStringDatabase(res_man);
+		}
 	}
+
+	return
+		db && XrmGetResource(db, name, name, &type, &ret) && STREQ(type, "String")
+		? ret.addr
+		: def
+		;
 }
 
 #define INIT_ATOM_(atom) \


### PR DESCRIPTION
`win_res()` is called multiple times when `sxiv` initializes, whenever an Xresource value is needed. For each call, `win_res()` creates an Xresources database from a specified window display.
1. First, it calls `XrmInitialize()` to initialize the Xresources manager
2. then calls `XResourceManagerString()` to get a pointer to the Xrm
3. then calls `XrmGetStringDatabase()` with the pointer to get a pointer to a new Xresources database
4. and finally, calls `XrmGetResource()` with the database pointer to get the `XrmValue`.

The leak occurs because `win_res()` stores the database pointer as an automatic and does not call `XrmDestroyDatabase()` before the pointer goes out of scope. The obvious fix is to call `XrmDestroyDatabase()` before returning. But this is not performant; since `win_res()` is called multiple times, we should avoid creating and destroying a database for each call.

The proposed fix is to have `win_res()` store the Xresources manager pointer and the database pointer as local statics. `win_res()` calls `XrmInitialize()`, `XResourceManagerString()`, and `XrmGetStringDatabase()` once, if the Xresources manager pointer has never been set. Thereafter, `win_res()` calls `XrmGetResource()` with the static database pointer for whatever value is needed. The end result is the database is created once and all memory will be collected when `sxiv` quits.

If `XResourceManagerString()` returns a null pointer, `win_res()` will continue to try to create a database for each call, but this will not be worse than the current situation.

If `XrmGetStringDatabase()` returns a null pointer, `win_res()` will return the given default value, as before, but a `?:` operator is used instead of an `if-else` statement.