### PR TITLE
docs: add ubuntu build dependencies section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ the following command:
     $ make config.h
 
 
+Build Dependencies
+------------------
+
+On ubuntu:
+
+    # sudo apt install libimlib2-dev
+
 Usage
 -----
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Build Dependencies
 
 On ubuntu:
 
-    # sudo apt install libimlib2-dev
+    # sudo apt install libimlib2-dev libexif-dev
 
 Usage
 -----


### PR DESCRIPTION
Hi, I tried building on ubuntu and was missing the imlib2 dependency, after googling a bit found the required package `libimlib2-dev`.

EDIT: also `libexif-dev`