### PR TITLE
Separated text color into it's own Xresource.

### DIFF
--- a/sxiv.1
+++ b/sxiv.1
@@ -379,10 +379,13 @@ Zoom out.
 The following X resources are supported:
 .TP
 .B background
-Color of the window background and bar foreground
+Color of the window background
 .TP
 .B foreground
 Color of the window foreground and bar background
+.TP
+.B textColor
+Color of the text in the bar
 .TP
 .B font
 Name of Xft bar font

--- a/sxiv.h
+++ b/sxiv.h
@@ -409,6 +409,7 @@ struct win {
 
 	XftColor bg;
 	XftColor fg;
+	XftColor tc;
 
 	int x;
 	int y;

--- a/window.c
+++ b/window.c
@@ -92,7 +92,7 @@ const char* win_res(XrmDatabase db, const char *name, const char *def)
 void win_init(win_t *win)
 {
 	win_env_t *e;
-	const char *bg, *fg, *f;
+	const char *bg, *fg, *tc, *f;
 	char *res_man;
 	XrmDatabase db;
 
@@ -121,8 +121,10 @@ void win_init(win_t *win)
 
 	bg = win_res(db, RES_CLASS ".background", "white");
 	fg = win_res(db, RES_CLASS ".foreground", "black");
+        tc = win_res(db, RES_CLASS ".textColor", "white");
 	win_alloc_color(e, bg, &win->bg);
 	win_alloc_color(e, fg, &win->fg);
+        win_alloc_color(e, tc, &win->tc);
 
 	win->bar.l.size = BAR_L_LEN;
 	win->bar.r.size = BAR_R_LEN;
@@ -408,12 +410,12 @@ void win_draw_bar(win_t *win)
 			return;
 		x = win->w - tw - H_TEXT_PAD;
 		w -= tw;
-		win_draw_text(win, d, &win->bg, x, y, r->buf, len, tw);
+		win_draw_text(win, d, &win->tc, x, y, r->buf, len, tw);
 	}
 	if ((len = strlen(l->buf)) > 0) {
 		x = H_TEXT_PAD;
 		w -= 2 * H_TEXT_PAD; /* gap between left and right parts */
-		win_draw_text(win, d, &win->bg, x, y, l->buf, len, w);
+		win_draw_text(win, d, &win->tc, x, y, l->buf, len, w);
 	}
 	XftDrawDestroy(d);
 }


### PR DESCRIPTION
Added the ability to set text color in the bar separately using it's own Xresource. This is because some background/foreground combinations do not provide enough contrast for text-readability.