### PR TITLE
Swap bar colors

### DIFF
--- a/window.c
+++ b/window.c
@@ -397,23 +397,23 @@ void win_draw_bar(win_t *win)
 	d = XftDrawCreate(e->dpy, win->buf.pm, DefaultVisual(e->dpy, e->scr),
 	                  DefaultColormap(e->dpy, e->scr));
 
-	XSetForeground(e->dpy, gc, win->fg.pixel);
+	XSetForeground(e->dpy, gc, win->bg.pixel);
 	XFillRectangle(e->dpy, win->buf.pm, gc, 0, win->h, win->w, win->bar.h);
 
-	XSetForeground(e->dpy, gc, win->bg.pixel);
-	XSetBackground(e->dpy, gc, win->fg.pixel);
+	XSetForeground(e->dpy, gc, win->fg.pixel);
+	XSetBackground(e->dpy, gc, win->bg.pixel);
 
 	if ((len = strlen(r->buf)) > 0) {
 		if ((tw = TEXTWIDTH(win, r->buf, len)) > w)
 			return;
 		x = win->w - tw - H_TEXT_PAD;
 		w -= tw;
-		win_draw_text(win, d, &win->bg, x, y, r->buf, len, tw);
+		win_draw_text(win, d, &win->fg, x, y, r->buf, len, tw);
 	}
 	if ((len = strlen(l->buf)) > 0) {
 		x = H_TEXT_PAD;
 		w -= 2 * H_TEXT_PAD; /* gap between left and right parts */
-		win_draw_text(win, d, &win->bg, x, y, l->buf, len, w);
+		win_draw_text(win, d, &win->fg, x, y, l->buf, len, w);
 	}
 	XftDrawDestroy(d);
 }


### PR DESCRIPTION
# Info
This PR simply swaps the bar colors, so that they are the same as the main colors.

## Why
I for one dislike a bright bar beneath my otherwise dark background.

## Screenshots
Before:
![2020-04-05_15-21](https://user-images.githubusercontent.com/9076894/78499474-3ac0ed80-7751-11ea-8260-7d6ad6ccb103.png)


After: 
![2020-04-05_15-19](https://user-images.githubusercontent.com/9076894/78499481-3eed0b00-7751-11ea-8222-adc60bdc210d.png)

## Future work
Ideally, this would be swappable on-demand via a config option or run-time argument.

This PR can probably be closed as it fundamentally changes a setting the author of sxiv probably prefers otherwise, but I still wanted to share the change for people inclined as me. I may open a different PR in the future to include this change as an optional feature.
