### PR TITLE
add option for dmenu like behaviour

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -65,8 +65,13 @@ bool cg_quit(arg_t _)
 	exit(EXIT_SUCCESS);
 }
 
-bool cg_switch_mode(arg_t _)
+bool cg_switch_mode(arg_t ignore_d)
 {
+    if (options->like_dmenu && !ignore_d) {
+        printf("%s\n", files[fileidx].name);
+        exit(EXIT_SUCCESS);
+    }
+
 	if (mode == MODE_IMAGE) {
 		if (tns.thumbs == NULL)
 			tns_init(&tns, files, &filecnt, &fileidx, &win);

--- a/config.def.h
+++ b/config.def.h
@@ -60,7 +60,8 @@ static const int THUMB_SIZE = 3;
 static const keymap_t keys[] = {
 	/* modifiers    key               function              argument */
 	{ 0,            XK_q,             g_quit,               None },
-	{ 0,            XK_Return,        g_switch_mode,        None },
+	{ 0,            XK_Return,        g_switch_mode,        0 },
+	{ ControlMask,  XK_Return,        g_switch_mode,        1 },
 	{ 0,            XK_f,             g_toggle_fullscreen,  None },
 	{ 0,            XK_b,             g_toggle_bar,         None },
 	{ ControlMask,  XK_x,             g_prefix_external,    None },

--- a/options.c
+++ b/options.c
@@ -30,7 +30,7 @@ const opt_t *options = (const opt_t*) &_options;
 
 void print_usage(void)
 {
-	printf("usage: sxiv [-abcfhiopqrtvZ] [-A FRAMERATE] [-e WID] [-G GAMMA] "
+	printf("usage: sxiv [-abcfhiodpqrtvZ] [-A FRAMERATE] [-e WID] [-G GAMMA] "
 	       "[-g GEOMETRY] [-N NAME] [-n NUM] [-S DELAY] [-s MODE] [-z ZOOM] "
 	       "FILES...\n");
 }
@@ -51,6 +51,7 @@ void parse_options(int argc, char **argv)
 
 	_options.from_stdin = false;
 	_options.to_stdout = false;
+	_options.like_dmenu = false;
 	_options.recursive = false;
 	_options.startnum = 0;
 
@@ -72,7 +73,7 @@ void parse_options(int argc, char **argv)
 	_options.clean_cache = false;
 	_options.private_mode = false;
 
-	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:opqrS:s:tvZz:")) != -1) {
+	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:odpqrS:s:tvZz:")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
@@ -128,6 +129,9 @@ void parse_options(int argc, char **argv)
 			case 'o':
 				_options.to_stdout = true;
 				break;
+            case 'd':
+                _options.like_dmenu = true;
+                break;
 			case 'p':
 				_options.private_mode = true;
 				break;

--- a/sxiv.h
+++ b/sxiv.h
@@ -261,6 +261,7 @@ struct opt {
 	char **filenames;
 	bool from_stdin;
 	bool to_stdout;
+	bool like_dmenu;
 	bool recursive;
 	int filecnt;
 	int startnum;


### PR DESCRIPTION
### Technicalities
The -d option will overwrite the default XK_Enter behaviour.

Instead of changing the mode sxiv will output the path to
the currently file indexed Image to stdout.

In order to still be able to change modes ctrl+enter will
ignore -d flag and changes modes as normally.

### Notes
 I am not a c dev but i feel like this was  simple enough to implement and potentially some more people would like sxiv to more closely imitate dmenu behaviour.

### Caveats
yes i am fully aware that -o -> mark one picture -> quit does effectively the same thing but the extra key press bothered me enough to dust of my c skills. I do however fully understand that this might seen as unnecessary in which case feel fee to decline the PR.