### PR TITLE
Added ICCCM WM_HINTS

### DIFF
--- a/window.c
+++ b/window.c
@@ -154,6 +154,7 @@ void win_open(win_t *win)
 	Pixmap none;
 	int gmask;
 	XSizeHints sizehints;
+	XWMHints hints;
 
 	e = &win->env;
 	parent = options->embed != 0 ? options->embed : RootWindow(e->dpy, e->scr);
@@ -251,6 +252,11 @@ void win_open(win_t *win)
 	sizehints.x = win->x;
 	sizehints.y = win->y;
 	XSetWMNormalHints(win->env.dpy, win->xwin, &sizehints);
+
+	hints.flags = InputHint | StateHint;
+	hints.input = 1;
+	hints.initial_state = NormalState;
+	XSetWMHints(win->env.dpy, win->xwin, &hints);
 
 	win->h -= win->bar.h;
 


### PR DESCRIPTION
When the window is mapped, some ICCCM WM_HINTS are set.
The input field is set to true and state is set to NormalState.

To quote the spec, "The input field is used to communicate to the window
manager the input focus model used by the client" and "[c]lients with
the Passive and Locally Active models should set the input flag to
True". sxiv falls under the Passive Input model, since it expects keyboard
input, but only listens for key events on its single, top-level window instead
of subordinate windows (Locally Active) or the root window (Globally Active).

From the end users prospective, all EWMH/ICCCM compliant WMs (especially
the minimalistic ones) will allow the user to focus sxiv, which will
allow sxiv to receive key events. If the input field is not set, WMs are
allowed to assume that sxiv doesn't require focus.


For reference, [the ICCC spec](https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#input_focus).

Summary of Input models
- No Input (false) - for windows that don't have keybindings
- Passive Input (true) - for windows whose keybindings are active only when the window has explicitly focus
- Locally Active (true) - for programs with multiple mapped windows
- Globally Active Input (true) - global keybindings

The reason why sxiv should provide WM_HINTS is because its perfectly acceptable for WMs to assume "convenient" values when they are not set. My ICCCM compliant, tiling WM (which is very similar to dwm and xmonad) choose to not give mpv focus which made it basically impossible to interact with it. Of course its trivial to tell the WM to give sxiv focus ahead of time, but wanted other people to not run it this problem.