### PR TITLE
Advertise Webp support in desktop file.

### DIFF
--- a/sxiv.desktop
+++ b/sxiv.desktop
@@ -3,6 +3,6 @@ Type=Application
 Name=sxiv
 GenericName=Image Viewer
 Exec=sxiv %F
-MimeType=image/bmp;image/gif;image/jpeg;image/jpg;image/png;image/tiff;image/x-bmp;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-tga;image/x-xpixmap;
+MimeType=image/bmp;image/gif;image/jpeg;image/jpg;image/png;image/tiff;image/x-bmp;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-tga;image/x-xpixmap;image/webp;
 NoDisplay=true
 Icon=sxiv


### PR DESCRIPTION
Since we already support single-frame WebP images through imlib2, we should disclose that in the desktop file.