### PR TITLE
removed unnecessary explicit case for escape key being pressed and...

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -149,4 +149,11 @@ static const button_t buttons[] = {
 	{ 0,            5,                g_zoom,               -1 },
 };
 
+
+/* if false, sxiv will send all key combos to the external keyhandler until the
+ * keyhandler returns 1 as its exit status.
+ * the example external keyhandler uses the escape key for this.
+ */
+static const bool one_extkeyhandler_cmd = true;
+
 #endif

--- a/exec/key-handler
+++ b/exec/key-handler
@@ -31,5 +31,6 @@ case "$1" in
 "C-comma")  rotate 270 ;;
 "C-period") rotate  90 ;;
 "C-slash")  rotate 180 ;;
+"Escape")   exit 1 ;;
 esac
 


### PR DESCRIPTION
...added option to allow multiple inputs to the external key handler at once.

The condition at main.c line 589-590
`if (ksym == XK_Escape && MODMASK(kev->state) == 0) {
		extprefix = False;`
is unnecessary because extprefix is set to false on line 593 no matter which key is pressed, including escape. Also, explicitly checking for XK_Escape means the user can't bind any commands to the escape key (i prefer to bind esc to 'exit without output' if possible). Also I added one_keyhandler_cmd, but the diff for config.def.h explains that well enough.