### PR TITLE
Add support for animated WebP images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,24 @@ HAVE_GIFLIB = 1
 # enable features requiring libexif (-lexif)
 HAVE_LIBEXIF = 1
 
+# enable features requiring libwebp (-lwebp)
+HAVE_LIBWEBP = 1
+
 cflags = -std=c99 -Wall -pedantic $(CFLAGS)
 cppflags = -I. $(CPPFLAGS) -D_XOPEN_SOURCE=700 \
   -DHAVE_GIFLIB=$(HAVE_GIFLIB) -DHAVE_LIBEXIF=$(HAVE_LIBEXIF) \
+  -DHAVE_LIBWEBP=$(HAVE_LIBWEBP) \
   -I/usr/include/freetype2 -I$(PREFIX)/include/freetype2
 
 lib_exif_0 =
 lib_exif_1 = -lexif
 lib_gif_0 =
 lib_gif_1 = -lgif
+lib_webp_0 =
+lib_webp_1 = -lwebp
 ldlibs = $(LDLIBS) -lImlib2 -lX11 -lXft -lfontconfig \
-  $(lib_exif_$(HAVE_LIBEXIF)) $(lib_gif_$(HAVE_GIFLIB))
+  $(lib_exif_$(HAVE_LIBEXIF)) $(lib_gif_$(HAVE_GIFLIB)) \
+  $(lib_webp_$(HAVE_LIBWEBP))
 
 objs = autoreload_$(AUTORELOAD).o commands.o image.o main.o options.o \
   thumbs.o util.o window.o

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ lib_exif_1 = -lexif
 lib_gif_0 =
 lib_gif_1 = -lgif
 lib_webp_0 =
-lib_webp_1 = -lwebp
+lib_webp_1 = -lwebpdemux -lwebp
 ldlibs = $(LDLIBS) -lImlib2 -lX11 -lXft -lfontconfig \
   $(lib_exif_$(HAVE_LIBEXIF)) $(lib_gif_$(HAVE_GIFLIB)) \
   $(lib_webp_$(HAVE_LIBWEBP))


### PR DESCRIPTION
`sxiv` doesn't support loading animated .webp images (since Imlib2 doesn't support it). I wrote a function `img_load_webp()` which mirrors the `img_load_gif()` function used to load animated gifs.

I had to also write a function to load the first frame of a webp file (I called it `load_webp_firstframe_im`, if you can think of a better name please rename it), because loading with Imlib2 fails and therefore the thumbnail was unable to load, deleting the image if thumbnail mode is entered. This caused a large amount of duplicated boilerplate for libWebP but I can't think of a better way to fix this issue.

I think I fixed all the memory leaks I had introduced with my changes. I removed all memory losses introduced in my test cases, but there is a chance that my tests were not extensive enough. There are still memory leaks but these existed before I changed anything, and they are small and don't seem to grow as the process remains active. This should probably be an issue, so I will create one if it isn't already.

Compiling the version with these changes requires all libraries that `sxiv` previously required and also libWebP (`-lwebp` and `-lwebpdemux`). I included `#if HAVE_LIBWEBP ... #endif` guards so `sxiv` can be compiled without webp support if desired (this can be toggled in the Makefile similar to `HAVE_GIFLIB`).