### PR TITLE
added a loader for svg images and modified Makefile enough so that it compiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ HAVE_GIFLIB = 1
 # enable features requiring libexif (-lexif)
 HAVE_LIBEXIF = 1
 
-cflags = -std=c99 -Wall -pedantic $(CFLAGS)
+cflags = -std=c99 -Wall -pedantic $(CFLAGS) `pkg-config --cflags --libs librsvg-2.0 cairo`
 cppflags = -I. $(CPPFLAGS) -D_XOPEN_SOURCE=700 \
   -DHAVE_GIFLIB=$(HAVE_GIFLIB) -DHAVE_LIBEXIF=$(HAVE_LIBEXIF) \
   -I/usr/include/freetype2 -I$(PREFIX)/include/freetype2
@@ -39,7 +39,7 @@ $(V).SILENT:
 
 sxiv: $(objs)
 	@echo "LINK $@"
-	$(CC) $(LDFLAGS) -o $@ $(objs) $(ldlibs)
+	$(CC) $(LDFLAGS) -o $@ $(objs) $(ldlibs) $(cflags)
 
 $(objs): Makefile sxiv.h commands.lst config.h
 options.o: version.h

--- a/image.c
+++ b/image.c
@@ -27,6 +27,9 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include<cairo.h>
+#include<librsvg/rsvg.h>
+
 #if HAVE_LIBEXIF
 #include <libexif/exif-data.h>
 #endif
@@ -293,6 +296,60 @@ bool img_load_gif(img_t *img, const fileinfo_t *file)
 }
 #endif /* HAVE_GIFLIB */
 
+Imlib_Image img_open_svg(const fileinfo_t *file)
+{
+	RsvgHandle *svg_handle = rsvg_handle_new_from_file(file->name, 0);
+	if (svg_handle == NULL)
+		return NULL;
+
+	gboolean has_out_height;
+	gboolean has_out_width;
+	gboolean has_out_viewbox;
+	RsvgLength out_height;
+	RsvgLength out_width;
+	RsvgRectangle out_viewbox;
+
+	rsvg_handle_get_intrinsic_dimensions(svg_handle,
+	                                     &has_out_height, &out_height,
+	                                     &has_out_width, &out_width,
+	                                     &has_out_viewbox, &out_viewbox);
+
+	double image_width, image_height;
+	if (has_out_height & has_out_width) {
+		image_height = out_height.length;
+		image_width = out_width.length;
+	} else if (has_out_viewbox) {
+		image_width = out_viewbox.height;
+		image_height = out_viewbox.width;
+	} else {
+		error(0, 0, "%s: Document does not specify height and width of image", file->name);
+		return NULL;
+	}
+
+	cairo_surface_t *surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
+	                                                      (int) image_height,
+	                                                      (int) image_width);
+	cairo_t *cr = cairo_create(surface);
+
+	rsvg_handle_render_cairo(svg_handle, cr);
+
+	DATA32 *svg_buffer;
+	svg_buffer = (DATA32 *) cairo_image_surface_get_data(surface);
+
+	Imlib_Image im = imlib_create_image_using_copied_data((int) image_height, (int) image_width, svg_buffer);
+	if (im == NULL)
+		return NULL;
+
+	imlib_context_set_image(im);
+	imlib_image_set_has_alpha(1);
+
+	cairo_surface_destroy(surface);
+	cairo_destroy(cr);
+	g_object_unref(svg_handle);
+
+	return im;
+}
+
 Imlib_Image img_open(const fileinfo_t *file)
 {
 	struct stat st;
@@ -302,6 +359,10 @@ Imlib_Image img_open(const fileinfo_t *file)
 	    stat(file->path, &st) == 0 && S_ISREG(st.st_mode))
 	{
 		im = imlib_load_image(file->path);
+
+		if (im == NULL)
+			im = img_open_svg(file);
+
 		if (im != NULL) {
 			imlib_context_set_image(im);
 			if (imlib_image_get_data_for_reading_only() == NULL) {


### PR DESCRIPTION
Hi,
This is a loader for svg images.

I am not very good at `Makefile` so I have modified it just enough so that the code compiles. `Makefile` has to be updated after this commit.

The following libraries are used for loading svg documents
* librsvg
* cairo

First the svg document is opened using `librsvg` and then rendered on a `cairo surface`, and finally the cairo surface pixel buffer is used to create an `Imlib_Image`.

dependencies also need to updated in README after this commit.